### PR TITLE
Avoid unintended double-slide switches

### DIFF
--- a/src/deck.js
+++ b/src/deck.js
@@ -135,6 +135,13 @@ class Deck extends Component {
   }
 
   handleWheel(e) {
+    // Only switch if the wheel has just started accelerating noticeably
+    let prevDeltaRatio = this.prevDeltaRatio;
+    let deltaRatio = this.prevWheelDelta ? e.deltaY / this.prevWheelDelta : 1;
+    this.prevDeltaRatio = deltaRatio;
+    this.prevWheelDelta = e.deltaY;
+    if (deltaRatio < 2 || prevDeltaRatio > 2) return;
+    
     let status = this.state.status;
     if (status !== STATUS.NORMAL || e.deltaY === 0 || this.isCurrentSlideScrolling(e.deltaY)) return;
 

--- a/src/deck.js
+++ b/src/deck.js
@@ -141,9 +141,6 @@ class Deck extends Component {
     this.prevDeltaRatio = deltaRatio;
     this.prevWheelDelta = e.deltaY;
     if (deltaRatio < 2 || prevDeltaRatio > 2) return;
-    
-    let status = this.state.status;
-    if (status !== STATUS.NORMAL || e.deltaY === 0 || this.isCurrentSlideScrolling(e.deltaY)) return;
 
     let { children: slides, loop, horizontal } = this.props;
     let prev = this.state.current, current = prev + (e.deltaY > 0 ? 1 : -1);
@@ -151,7 +148,7 @@ class Deck extends Component {
     current = loop ? (current + slidesCount) % slidesCount : current;
 
     if (current >= 0 && current < slidesCount) {
-      status = STATUS.FORWARDING | (e.deltaY > 0 ? STATUS.DOWN : STATUS.UP);
+      let status = STATUS.FORWARDING | (e.deltaY > 0 ? STATUS.DOWN : STATUS.UP);
       this.setState({ prev, current, status });
       this.startTran(0, (status & STATUS.DOWN ? -1 : 1) * (horizontal ? this.state.width : this.state.height));
     }


### PR DESCRIPTION
It appears that scroll wheel events keep getting processed long after the user actually removes their fingers from the trackpad, with the result that if I swipe for 800ms, even if the swipe duration is 1000ms, it will usually end up triggering a second swipe after the first one finishes.

This fixes that by making sure the _speed_ of the scroll wheel has just spiked (and wasn't already spiking earlier), so that we only get one slide change per swipe motion on a trackpad.

Feel free to play around with this! Thanks a lot for this library—we're using it in a new repository at Tictail, and we subclassed `Deck` with this change in order to get the behavior we wanted. It would be nice if the change were made upstream, though, so we could get rid of our child class.
